### PR TITLE
adde width and height

### DIFF
--- a/depthview/depth_view.py
+++ b/depthview/depth_view.py
@@ -11,7 +11,7 @@ import open3d as o3d
 from tqdm import tqdm
 
 
-from zed_camerainfo import CameraParmeter
+from depthview.zed_camerainfo import CameraParmeter
 
 def finitemax(depth: np.ndarray) -> float:
     return np.nanmax(depth[np.isfinite(depth)])

--- a/depthview/depth_view.py
+++ b/depthview/depth_view.py
@@ -11,6 +11,8 @@ import open3d as o3d
 from tqdm import tqdm
 
 
+from zed_camerainfo import CameraParmeter
+
 def finitemax(depth: np.ndarray) -> float:
     return np.nanmax(depth[np.isfinite(depth)])
 
@@ -97,6 +99,22 @@ def view3d(args):
     left_images = sorted(leftdir.glob("**/*.png"))
     depth_npys = sorted(zeddepthdir.glob("**/*.npy"))
 
+    json_file = captured_dir / "camera_param.json"
+    camera_parameter = CameraParmeter.load_json(json_file)
+
+    width = camera_parameter.width
+    height = camera_parameter.height
+    fx = camera_parameter.fx
+    fy = camera_parameter.fy
+    cx = camera_parameter.cx
+    cy = camera_parameter.cy
+
+    # fx = 532.41
+    # fy = 532.535
+    # cx = 636.025  # [pixel]
+    # cy = 362.4065  # [pixel]
+    left_cam_intrinsic = o3d.camera.PinholeCameraIntrinsic(width=width, height=height, fx=fx, fy=fy, cx=cx, cy=cy)
+
     vis = o3d.visualization.Visualizer()
     vis.create_window()
     for leftname, depth_name in zip(left_images, depth_npys):
@@ -109,11 +127,6 @@ def view3d(args):
         rgbd_image = o3d.geometry.RGBDImage.create_from_color_and_depth(rgb, open3d_depth)
         # [LEFT_CAM_HD]
         height, width = image.shape[:2]
-        fx = 532.41
-        fy = 532.535
-        cx = 636.025  # [pixel]
-        cy = 362.4065  # [pixel]
-        left_cam_intrinsic = o3d.camera.PinholeCameraIntrinsic(width=width, height=height, fx=fx, fy=fy, cx=cx, cy=cy)
 
         pcd = o3d.geometry.PointCloud.create_from_rgbd_image(rgbd_image, left_cam_intrinsic)
         pcd.transform([[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]])

--- a/depthview/zed_camerainfo.py
+++ b/depthview/zed_camerainfo.py
@@ -4,12 +4,12 @@ from dataclasses import dataclass, field
 from dataclasses_json import dataclass_json
 from pathlib import Path
 
-def get_fx_fy_cx_cy(left_cam_params):
+def get_width_height_fx_fy_cx_cy(left_cam_params):
     """
     Note:
         left_cam_params = cam_info.camera_configuration.calibration_parameters.left_cam
     """
-    return left_cam_params.fx, left_cam_params.fy, left_cam_params.cx, left_cam_params.cy
+    return left_cam_params.image_size.width, left_cam_params.image_size.height, left_cam_params.fx, left_cam_params.fy, left_cam_params.cx, left_cam_params.cy
 
 
 def get_baseline(cam_info) -> float:
@@ -30,15 +30,17 @@ def load_settings():
 @dataclass_json
 @dataclass
 class CameraParmeter:
+    width: int = 0  # [pixel]
+    height: int = 0  # [pixel]
     fx: float = 0.0
     fy: float = 0.0
-    cx: float = 0.0
-    cy: float = 0.0
+    cx: float = 0.0  # [pixel]
+    cy: float = 0.0  # [pixel]
     baseline: float = 0.0
 
     def get_current_setting(self, cam_info):
         left_cam_params = cam_info.camera_configuration.calibration_parameters.left_cam
-        self.fx, self.fy, self.cx, self.cy = get_fx_fy_cx_cy(left_cam_params)
+        self.width, self.height, self.fx, self.fy, self.cx, self.cy = get_width_height_fx_fy_cx_cy(left_cam_params)
         self.baseline = get_baseline(cam_info)
 
     def save_json(self, name: Path):
@@ -51,10 +53,9 @@ class CameraParmeter:
     @classmethod
     def create(cls, cam_info):
         left_cam_params = cam_info.camera_configuration.calibration_parameters.left_cam
-        fx, fy, cx, cy = get_fx_fy_cx_cy(left_cam_params)
+        width, height, fx, fy, cx, cy = get_width_height_fx_fy_cx_cy(left_cam_params)
         baseline = get_baseline(cam_info)
-
-        return cls(fx=fx, fy=fy, cx=cx, cy=cy, baseline=baseline)
+        return cls(width=width, height=height, fx=fx, fy=fy, cx=cx, cy=cy, baseline=baseline)
 
 if __name__ == "__main__":
     # Create a ZED camera object
@@ -112,14 +113,14 @@ if __name__ == "__main__":
     print("\n")
     print(f"{cam_info.camera_configuration.calibration_parameters.get_camera_baseline()=}")
 
-    print(f"{get_fx_fy_cx_cy(left_cam_params)=}")
-    fx, fy, cx, cy = get_fx_fy_cx_cy(left_cam_params)
+    print(f"{get_width_height_fx_fy_cx_cy(left_cam_params)=}")
+    width, height, fx, fy, cx, cy = get_width_height_fx_fy_cx_cy(left_cam_params)
     print(f"{get_baseline(cam_info)}")
     baseline = get_baseline(cam_info)
     # Close the camera
     zed.close()
 
-    camera_parameter = CameraParmeter(fx=fx, fy=fy, cx=cx, cy=cy, baseline=baseline)
+    camera_parameter = CameraParmeter(width=width, height=height, fx=fx, fy=fy, cx=cx, cy=cy, baseline=baseline)
     print(camera_parameter)
     print(camera_parameter.to_json())
 


### PR DESCRIPTION
# why
- Improve compatibility of json file parameters with PinholeCameraIntrinsic().
# what
- Fixed to use image_size.width, image_size.height.

# checked
following command worked.
```
zed_capture
depth_viewer --disp3d outdir
```